### PR TITLE
[DO NOT MERGE] Helm chart-testing failure example

### DIFF
--- a/kubernetes/examples/helm-chart-testing-examples/cluster-issuer/Chart.yaml
+++ b/kubernetes/examples/helm-chart-testing-examples/cluster-issuer/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 name: cluster-issuer
-version: v0.1.2
+version: v0.1.3
 appVersion: v0.1.1
 description: A Helm chart to create the cert-manager cluster issuers
 home: foo-bar-required-home-field

--- a/kubernetes/examples/helm-chart-testing-examples/cluster-issuer/ci/enable-dns01-issuer-values.yaml
+++ b/kubernetes/examples/helm-chart-testing-examples/cluster-issuer/ci/enable-dns01-issuer-values.yaml
@@ -1,5 +1,5 @@
 ---
 issuer:
   dns:
-    enabled: false
+    enabled: true
     name: issuer-dns01

--- a/kubernetes/examples/helm-chart-testing-examples/cluster-issuer/templates/dns01.yaml
+++ b/kubernetes/examples/helm-chart-testing-examples/cluster-issuer/templates/dns01.yaml
@@ -3,6 +3,7 @@
 ---
 apiVersion: cert-manager.io/v1alpha2
 kind: ClusterIssuer
+foo
 metadata:
   name: {{ .Values.issuer.dns.name }}
   namespace: {{ .Values.namespace }}


### PR DESCRIPTION
This is an example of how the `chart-testing` linter tool works.  The `README.md` describes how this tool works and what it can find by linting out the Helm charts.

https://github.com/ManagedKube/kubernetes-common-services/tree/master/kubernetes/examples/helm-chart-testing-examples/cluster-issuer#this-is-a-test-chart-to-show-the-functionality-of-the-chart-testing-tool