### PR TITLE
Revert "Updating external-dns to Helm version: 2.21.2"

### DIFF
--- a/kubernetes/flux/releases/gcp/dev/external-dns/helmrelease.yaml
+++ b/kubernetes/flux/releases/gcp/dev/external-dns/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: external-dns
 spec:
   chart:
-    version: 2.21.2
+    version: 2.5.3
   values:
     ## The dns provider
     provider: google


### PR DESCRIPTION
Reverts ManagedKube/kubernetes-common-services#5