### PR TITLE
Updating nginx-ingress helm chart to version 1.36.3

### DIFF
--- a/kubernetes/flux/releases/gcp/dev/nginx-ingress/external/helmrelease.yaml
+++ b/kubernetes/flux/releases/gcp/dev/nginx-ingress/external/helmrelease.yaml
@@ -6,7 +6,7 @@ metadata:
   namespace: ingress
 spec:
   chart:
-    version: 1.36.0
+    version: 1.36.3
   values:
     controller:
       electionID: ingress-controller-leader-external


### PR DESCRIPTION
Updating nginx-ingress helm chart to version 1.36.3

Upstream chart: https://github.com/helm/charts/blob/master/stable/nginx-ingress
Upstream chart PR: https://github.com/helm/charts/pull/21950
Description of changes:
```
What this PR does / why we need it:

The PDB's currently will not match the pods they are intended to by default.

I'm not sure why the PDB had an if statement around the new label as it gets applied to every pod regardless of what's set for .Values.controller.useComponentLabel.
```